### PR TITLE
Ability to control and test if interaction is allowed

### DIFF
--- a/Source/ActorInteractionPlugin/Private/ActorInteractionInterface.cpp
+++ b/Source/ActorInteractionPlugin/Private/ActorInteractionInterface.cpp
@@ -1,0 +1,1 @@
+#include "ActorInteractionInterface.h"

--- a/Source/ActorInteractionPlugin/Private/Components/ActorInteractableComponent.cpp
+++ b/Source/ActorInteractionPlugin/Private/Components/ActorInteractableComponent.cpp
@@ -342,6 +342,11 @@ void UActorInteractableComponent::SetInteractionState(const EInteractableState N
 	/* Full State Machine is available in Documentation
 	 * @see https://sites.google.com/view/dominikpavlicek/home/documentation
 	*/
+	if (NewState == EInteractableState::EIS_Disabled)
+	{
+		InteractableState = NewState;
+		return;
+	}
 	switch (GetInteractionState())
 	{
 		case EInteractableState::EIS_Standby:
@@ -369,7 +374,8 @@ void UActorInteractableComponent::SetInteractionState(const EInteractableState N
 			}
 			break;
 		case EInteractableState::EIS_Finished:
-				InteractableState = NewState;
+			InteractableState = NewState;
+			break;
 		case EInteractableState::EIS_Disabled:
 			if(NewState == EInteractableState::EIS_Inactive)
 			{

--- a/Source/ActorInteractionPlugin/Private/Components/ActorInteractorComponent.cpp
+++ b/Source/ActorInteractionPlugin/Private/Components/ActorInteractorComponent.cpp
@@ -249,7 +249,7 @@ void UActorInteractorComponent::TickInteraction(const float DeltaTime)
 						AActor* InteractableActor = InteractableComponent->GetOwner();
 						if (InteractableActor->GetClass()->ImplementsInterface(UActorInteractionInterface::StaticClass()))
 						{
-							if (!IActorInteractionInterface::Execute_CanInteract(InteractableActor, GetOwner()))
+							if (!IActorInteractionInterface::Execute_CanInteract(InteractableActor, InteractableComponent, GetOwner()))
 								continue;
 						}
 

--- a/Source/ActorInteractionPlugin/Private/Components/ActorInteractorComponent.cpp
+++ b/Source/ActorInteractionPlugin/Private/Components/ActorInteractorComponent.cpp
@@ -3,6 +3,8 @@
 
 #include "Components/ActorInteractorComponent.h"
 
+#include "ActorInteractionInterface.h"
+
 #include "Components/ActorInteractableComponent.h"
 #include "Kismet/KismetMathLibrary.h"
 #include "Helpers/ActorInteractionPluginLog.h"
@@ -244,6 +246,13 @@ void UActorInteractorComponent::TickInteraction(const float DeltaTime)
 					UActorInteractableComponent* InteractableComponent = Cast<UActorInteractableComponent>(Itr);
 					if(InteractableComponent->FindCollisionShape(HitComponent))
 					{
+						AActor* InteractableActor = InteractableComponent->GetOwner();
+						if (InteractableActor->GetClass()->ImplementsInterface(UActorInteractionInterface::StaticClass()))
+						{
+							if (!IActorInteractionInterface::Execute_CanInteract(InteractableActor, GetOwner()))
+								continue;
+						}
+
 						if (InteractableComponent != InteractingWith)
 						{
 							LastInteractionTickTime = WorldTime;

--- a/Source/ActorInteractionPlugin/Public/ActorInteractionInterface.h
+++ b/Source/ActorInteractionPlugin/Public/ActorInteractionInterface.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "UObject/Interface.h"
+
+#include "ActorInteractionInterface.generated.h"
+
+UINTERFACE(BlueprintType)
+class ACTORINTERACTIONPLUGIN_API UActorInteractionInterface : public UInterface
+{
+	GENERATED_BODY()
+};
+
+class ACTORINTERACTIONPLUGIN_API IActorInteractionInterface
+{
+	GENERATED_BODY()
+
+public:
+	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category = "Interaction")
+	bool CanInteract(const AActor* With);
+};

--- a/Source/ActorInteractionPlugin/Public/ActorInteractionInterface.h
+++ b/Source/ActorInteractionPlugin/Public/ActorInteractionInterface.h
@@ -5,6 +5,8 @@
 
 #include "ActorInteractionInterface.generated.h"
 
+class UActorInteractableComponent;
+
 UINTERFACE(BlueprintType)
 class ACTORINTERACTIONPLUGIN_API UActorInteractionInterface : public UInterface
 {
@@ -17,5 +19,5 @@ class ACTORINTERACTIONPLUGIN_API IActorInteractionInterface
 
 public:
 	UFUNCTION(BlueprintCallable, BlueprintNativeEvent, Category = "Interaction")
-	bool CanInteract(const AActor* With);
+	bool CanInteract(const UActorInteractableComponent* Interactable, const AActor* With);
 };


### PR DESCRIPTION
This PR consists of two commits:

1. Makes it possible for Interactable to go to DISABLED state from any other state.
2. Adds IActorInteractionInterface so Interactor may test if interaction is possible during trace. This way more details may be added in decision to allow or forbid the interaction. For example, interaction may be allowed or forbidden based on relative transform between two actors, state of their inventory etc.

 IActorInteractionInterface is intended to be implemented by Actor that owns Interactable Component.